### PR TITLE
Fixed blank CK keys and improved debug logs

### DIFF
--- a/src/JuliusSweetland.OptiKey/UI/Controls/CK20Page.xaml.cs
+++ b/src/JuliusSweetland.OptiKey/UI/Controls/CK20Page.xaml.cs
@@ -117,10 +117,14 @@ namespace JuliusSweetland.OptiKey.UI.Controls
                                         blankbutton.image_id = "back.png";
                                         blankbutton.load_board = new Load_board();
                                         blankbutton.load_board.path = "boards/" + Settings.Default.CommuniKateKeyboardPrevious1Context;
+                                        Log.DebugFormat("Back button {3} added at column {0} row {1} with background colour {2}.", c, r, blankbutton.background_color, BlankButtonCount);
+                                    }
+                                    else
+                                    {
+                                        Log.DebugFormat("Blank button {3} added at column {0} row {1} with background colour {2}.", c, r, blankbutton.background_color, BlankButtonCount);
                                     }
                                     blankbutton.id = c.ToString() + r.ToString();
                                     CKPageOBF.buttons.Insert(b, blankbutton);
-                                    Log.DebugFormat("Blank button {3} added at column {0} row {1} with background colour {2}.", c, r, blankbutton.background_color, BlankButtonCount);
                                     --BlankButtonCount;
                                 }
                                 else if (CKPageOBF.buttons.ElementAt(b).load_board == null && blankbutton.background_color == "rgb(0,0,0)")
@@ -138,10 +142,14 @@ namespace JuliusSweetland.OptiKey.UI.Controls
                                     blankbutton.image_id = "back.png";
                                     blankbutton.load_board = new Load_board();
                                     blankbutton.load_board.path = "boards/" + Settings.Default.CommuniKateKeyboardPrevious1Context;
+                                    Log.DebugFormat("Back button {3} added at column {0} row {1} with background colour {2}.", c, r, blankbutton.background_color, BlankButtonCount);
+                                }
+                                else
+                                {
+                                    Log.DebugFormat("Blank button {3} added at column {0} row {1} with background colour {2}.", c, r, blankbutton.background_color, BlankButtonCount);
                                 }
                                 blankbutton.id = c.ToString() + r.ToString();
                                 CKPageOBF.buttons.Insert(b, blankbutton);
-                                Log.DebugFormat("Blank button {3} added at column {0} row {1} with background colour {2}.", c, r, blankbutton.background_color, BlankButtonCount);
                                 --BlankButtonCount;
                             }
                             ++b;

--- a/src/JuliusSweetland.OptiKey/UI/Controls/Key.cs
+++ b/src/JuliusSweetland.OptiKey/UI/Controls/Key.cs
@@ -73,7 +73,7 @@ namespace JuliusSweetland.OptiKey.UI.Controls
             SelectionInProgress = progress > 0d;
 
             //Calculate IsEnabled
-            Action calculateIsEnabled = () => IsEnabled = Value != null && keyStateService.KeyEnabledStates[Value];
+            Action calculateIsEnabled = () => IsEnabled = (Value != null || HasImage) && keyStateService.KeyEnabledStates[Value];
             var keyEnabledSubscription = keyStateService.KeyEnabledStates
                 .OnAnyPropertyChanges()
                 .Subscribe(_ => calculateIsEnabled());


### PR DESCRIPTION
The blank CK keys were always black because they have a null Value and so
were disabled. The IsEnabled calculation now checks ```(Value != null || HasImage)```.

The debug log for the inserted CK Back key is now a separate message from
the insertion of blank keys.